### PR TITLE
ecs config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,31 @@ services:
       - "80:80"
     depends_on:
       - backend
+    links:
+      - "backend"    
+    logging:
+      driver: awslogs
+      options: 
+        awslogs-group: frontend
+        awslogs-region: eu-central-1
+        awslogs-stream-prefix: ecs-terraform-free-tier
   backend:
     image: r.cfcr.io/jbojcic1/tax-form-generator-api:docker-2
+    hostname: "backend"
+    ports:
+    - "5000:5000"
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: backend
+        awslogs-region: eu-central-1
+        awslogs-stream-prefix: ecs-terraform-free-tier
   migrations:
-    image: r.cfcr.io/jbojcic1/tax-form-generator-api-migrations:docker-2
+    image: r.cfcr.io/jbojcic1/tax-form-generator-api-migrations:docker-2      
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: migrations
+        awslogs-region: eu-central-1
+        awslogs-stream-prefix: ecs-terraform-free-tier
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,6 @@ services:
         awslogs-stream-prefix: ecs-terraform-free-tier
   backend:
     image: r.cfcr.io/jbojcic1/tax-form-generator-api:docker-2
-    hostname: "backend"
-    ports:
-    - "5000:5000"
     logging:
       driver: awslogs
       options:

--- a/ecs-params.yml
+++ b/ecs-params.yml
@@ -1,0 +1,20 @@
+version: 1
+task_definition:
+  ecs_network_mode: bridge      
+  task_size:
+    cpu_limit: 512
+    mem_limit: 512
+  services:
+    backend:
+      essential: true
+      mem_limit: 512
+      cpu_shares: 256
+    frontend:
+      essential: false
+      mem_limit: 128
+      cpu_shares: 128
+    migrations: 
+      essential: false
+      mem_limit: 256
+      cpu_shares: 128
+


### PR DESCRIPTION
We need to run these commands to deploy containers to ecs

* Configure cluster
```bash
ecs-cli configure --cluster ecs-terraform-free-tier --default-launch-type EC2 --region eu-central-1
```

* Setup profile (default one is `default`)
```bash
 ecs-cli configure profile --profile-name jkobejs
```

* Deploy
```bash
ecs-cli compose service up --aws-profile jkobejs --cluster ecs-terraform-free-tier --target-group-arn arn:aws:elasticloadbalancing:eu-central-1:680562102875:targetgroup/dft20200504155545329000000009/a7284e28dd1557d5 --create-log-groups --container-name frontend --container-port 80 --force-deployment
```